### PR TITLE
Interp beam areas

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ First install dependencies.
 * astropy >= 2.0
 * h5py (for uvh5 compatibility with pyuvdata, optional)
 * six >= 1.10 (for compatibility between python 2 and 3)
+* astropy-healpix used for UVBeam interpolations through pyuvdata (optional, only used with `use_exact` keyword for `add_uvbeam`)
 * pyuvdata >=1.3.8 (conda install -c conda-forge pyuvdata, `pip install pyuvdata`, or use the development version  https://github.com/RadioAstronomySoftwareGroup/pyuvdata.git)
 
 For anaconda users, we suggest using conda to install astropy, numpy and scipy.
@@ -52,6 +53,7 @@ Clone the repo using
 `git clone https://github.com/rasg-affiliates/simpleDS.git`
 
 Navigate into the directory and run `python setup.py install` or `pip install .`
+To also install the optional `astropy-healpix` use `pip install .[all]`
 
 ## Running Tests
 We use `pytest` to execute the tests for this pacakge.

--- a/ci/tests.yaml
+++ b/ci/tests.yaml
@@ -4,6 +4,7 @@ channels:
   - conda-forge
 dependencies:
   - astropy
+  - astropy-healpix
   - numpy
   - scipy
   - six

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ setup_args = {
         "pyuvdata>=1.3.8",
         "six>=1.10",
     ],
+    "extras_require": {"all": ["astropy-healpix"]},
     "tests_require": ["pytest"],
 }
 

--- a/simpleDS/tests/test_delay_spectrum.py
+++ b/simpleDS/tests/test_delay_spectrum.py
@@ -573,7 +573,6 @@ def test_loading_uvb_object_with_trcvr_interp():
     uvb.receiver_temperature_array = np.ones((1, uvb.Nfreqs)) * 144
     uvb.select(frequencies=uvb.freq_array.squeeze()[::2])
     dspec_object.add_uvbeam(uvb=uvb, use_exact=False)
-    uvb.select(frequencies=uvd.freq_array[0])
     assert np.allclose(144, dspec_object.trcvr.to("K")[0].value)
 
 

--- a/simpleDS/tests/test_delay_spectrum.py
+++ b/simpleDS/tests/test_delay_spectrum.py
@@ -459,6 +459,8 @@ def test_add_uvb_interp_areas():
     uvb = UVBeam()
     uvb.read_beamfits(test_uvb_file)
     dspec_object.add_uvbeam(uvb=uvb, use_exact=True)
+    uvb.freq_array += 1e6  # Add 1 MHz to force interpolation
+    assert uvb.freq_array != dspec_object.freq_array
     dspec_object2.add_uvbeam(uvb=uvb)
 
     assert np.allclose(

--- a/simpleDS/tests/test_delay_spectrum.py
+++ b/simpleDS/tests/test_delay_spectrum.py
@@ -560,6 +560,23 @@ def test_loading_uvb_object_with_trcvr():
     )
 
 
+def test_loading_uvb_object_with_trcvr_interp():
+    """Test a uvb object with trcvr gets added properly."""
+    testfile = os.path.join(UVDATA_PATH, "test_redundant_array.uvfits")
+    test_uvb_file = os.path.join(DATA_PATH, "test_redundant_array.beamfits")
+    uvd = UVData()
+    uvd.read(testfile)
+    dspec_object = DelaySpectrum(uv=uvd)
+
+    uvb = UVBeam()
+    uvb.read_beamfits(test_uvb_file)
+    uvb.receiver_temperature_array = np.ones((1, uvb.Nfreqs)) * 144
+    uvb.select(frequencies=uvb.freq_array.squeeze()[::2])
+    dspec_object.add_uvbeam(uvb=uvb, use_exact=False)
+    uvb.select(frequencies=uvd.freq_array[0])
+    assert np.allclose(144, dspec_object.trcvr.to("K")[0].value)
+
+
 def test_add_trcvr_scalar():
     """Test a scalar trcvr quantity is broadcast to the correct shape."""
     testfile = os.path.join(UVDATA_PATH, "test_redundant_array.uvfits")


### PR DESCRIPTION
interpolates the beam area and beam_sq_area by default to match the delayspectrum object, should protect when beam file does not match the frequencies exactly.